### PR TITLE
Remove unsigned emblems

### DIFF
--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -26,7 +26,7 @@ This is often a separate entity from the creator or original designer of the emb
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.
 To be effective, the semantics of an emblem must be well known, easily recognizable, and distinguishable from other emblems.
 
-Digital emblems can be self-signed or signed by a trust anchor.
+Digital emblems can be integrity-protected by another layer, self-signed or signed by a trust anchor.
 Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.
 
 # Initial Scope

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -24,6 +24,7 @@ This is often a separate entity from the creator or original designer of the emb
 
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.
+Cryptographic verification may or may not be used based on the in-place security mechanisms of the communication channel bearing the emblem.
 To be effective, the semantics of an emblem must be well known, easily recognizable, and distinguishable from other emblems.
 
 Digital emblems can be integrity-protected by another layer, self-signed or signed by a trust anchor.

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -24,11 +24,9 @@ This is often a separate entity from the creator or original designer of the emb
 
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.
-Cryptographic verification can be optional as long as the emblem can be correctly interpreted.
-Therefore, to be effective, the semantics of an emblem must be well known, easily recognizable, and distinguishable from other emblems.
+To be effective, the semantics of an emblem must be well known, easily recognizable, and distinguishable from other emblems.
 
-
-Digital emblems can be unsigned, self-signed, or signed by a trust anchor.
+Digital emblems can be self-signed or signed by a trust anchor.
 Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.
 
 # Initial Scope


### PR DESCRIPTION
The justification for any potential benefit of unsigned emblems is almost non-existent; the danger of trusting unsigned emblems is very high. Meanwhile the charter rules out of scope a number of tractable problems with well-defined use cases.

This goes against the spirit and practice of RFC 3365 (BCP 61), without a good reason.