### PR TITLE
Rework architectural considerations

### DIFF
--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -25,8 +25,6 @@ This is often a separate entity from the creator or original designer of the emb
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.
 Cryptographic verification may or may not be used based on the in-place security mechanisms of the communication channel bearing the emblem.
-
-Digital emblems can be integrity-protected by another layer, self-signed or signed by a trust anchor.
 Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.
 
 # Initial Scope

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -25,7 +25,6 @@ This is often a separate entity from the creator or original designer of the emb
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.
 Cryptographic verification may or may not be used based on the in-place security mechanisms of the communication channel bearing the emblem.
-To be effective, the semantics of an emblem must be well known, easily recognizable, and distinguishable from other emblems.
 
 Digital emblems can be integrity-protected by another layer, self-signed or signed by a trust anchor.
 Which attributes an emblem contains, and how a digital emblem is secured and presented impacts how a validator interprets and trusts the assertions made within the emblem.


### PR DESCRIPTION
Aims to close #32.

Roman raised three points. I think the third one need not be addressed as commented in #32.

1. What does “easily recognizable” and “distinguishable” mean in the digital sense?
  - I have no idea, so I would remove the sentence. The sentence's role is unclear.
2. “Digital emblems can be unsigned, self-signed, or signed by a trust anchor”,
is DIEM going to define a “binding protocol” and “discovery protocol” for
emblems of these three flavors?
  - I don't think this is a critical problem, deliverable 3 is sufficiently clear in my eyes. However, I think that the sentence in line 27 makes the sentence in line 30 fully redundant, so it's clearer to remove line 30. Less ambiguity.