### PR TITLE
Remove sentence without clear role

### DIFF
--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -8,7 +8,6 @@ to digital infrastructure.
 There is a need to present emblems through digital communication channels.
 
 Digital emblems extend the range of identifying marks from the physical (visual and tactile) to the digital realm.
-The presence of a digital emblem represents a new signal available to cyber operators. 
 
 The DIEM WG will define an architecture and discovery mechanism enabling digital emblems to be presented and validated across applications and platforms in a cohesive way.
 


### PR DESCRIPTION
Title says it all. Roman had also commented upon this sentence in his block:

> ** Is the sentence “The presence of a digital emblem represents a new signal available to cyber operators” intended to narrow the scope?  Is the signal useful to other users? Wouldn’t there be a safety use case for the ISO 7010 symbols?

I think we're better off removing it.