### PR TITLE
More Terminology

### DIFF
--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -18,10 +18,6 @@ The DIEM WG will define an architecture and discovery mechanism enabling digital
 The entity that bears the emblem is respectively the bearer or emblem holder. 
 This is often a separate entity from the creator or original designer of the emblem.
 
-A "discovery mechanism" enables clients to discover emblem bearers such that the emblem bearer can present their emblem to the client.
-For example, a registry providing a list of domain names that provide TLS-endpoints can be a discovery mechanism.
-Clients could search the registry, connect to the endpoint using TLS, and be presented that endpoint's emblems.
-
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Validation may include ensuring that the bearer has not forged, stolen, or tampered with an emblem.
 Emblems may be observed by validators without the knowledge of the bearer displaying the emblem, or may be presented to a specific validator upon request.

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -17,7 +17,6 @@ The DIEM WG will define an architecture and discovery mechanism enabling digital
 "To bear an emblem" means to present or display and be identified by a digital emblem.
 The entity that bears the emblem is respectively the bearer or emblem holder. 
 This is often a separate entity from the creator or original designer of the emblem.
-Identification can be explicit, i.e., the emblem contains an identifier of the bearer, or implicit, for example, an emblem presented over a channel such as TLS can implicitly identify the sender as bearer.
 
 A "discovery mechanism" enables clients to discover emblem bearers such that the emblem bearer can present their emblem to the client.
 For example, a registry providing a list of domain names that provide TLS-endpoints can be a discovery mechanism.

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -6,17 +6,22 @@ be identified by other laws or ISO standards that parties need to be able to app
 to digital infrastructure.
 
 There is a need to present emblems through digital communication channels.
-
+Emblems presented in such ways are called digital emblems.
 Digital emblems extend the range of identifying marks from the physical (visual and tactile) to the digital realm.
 The presence of a digital emblem represents a new signal available to cyber operators. 
 
 The DIEM WG will define an architecture and discovery mechanism enabling digital emblems to be presented and validated across applications and platforms in a cohesive way.
 
-# Architectural Consideration
+# Terminology
 
-"To bear an emblem" means to present or display an identifying mark. 
+"To bear an emblem" means to present or display and be identified by a digital emblem.
 The entity that bears the emblem is respectively the bearer or emblem holder. 
 This is often a separate entity from the creator or original designer of the emblem.
+Identification can be explicit, i.e., the emblem contains an identifier of the bearer, or implicit, for example, an emblem presented over a channel such as TLS can implicitly identify the sender as bearer.
+
+A "discovery mechanism" enables clients to discover emblem bearers such that the emblem bearer can present their emblem to the client.
+For example, a registry providing a list of domain names that provide TLS-endpoints can be a discovery mechanism.
+Clients could search the registry, connect to the endpoint using TLS, and be presented that endpoint's emblems.
 
 "To validate an emblem" means to confirm the authenticity or legitimacy of a particular symbol or design, often by checking its details against a known standard or reference point. 
 Validation may include ensuring that the bearer has not forged, stolen, or tampered with an emblem.


### PR DESCRIPTION
This PR is likely more controversial. I think we need to define some more terminology. While I was at it, I renamed "Architectural Considerations" to "Terminology," which I find more accurate.

My changes were motivated by the following:
- Define "digital emblem." So far, this was only done implicitly. The definition is rather technical, but I think it helps to make it explicit.
- Mention that emblems identify their bearer. I think this is necessary for later changes to scope. Also, Roman had asked question on whether the emblem identifies the bearer in his block vote:
  > ** The introduction and architectural considerations sections describe the properties of an emblem.  The text would benefit from some notional scoping definition of a “bearer” that is being bound the to the digital emblem.
  >
  > -- Is a bearer an identifier such as an IP address or domain name?
  > 
  > -- If the bearer is an identifier, is there a fixed list that the WG will focus on?
- Then I go on to define "discovery mechanism." The term is used a lot in scoping and deliverables but never defined.

I tried being accurate and not focussing on specific use cases in my definitions. Should anyone see my definitions as not sufficiently general, please let me know.