### PR TITLE
fix: implication that lopresti-open-cloud-mesh is the only available …

### DIFF
--- a/ocm/charter.md
+++ b/ocm/charter.md
@@ -39,7 +39,7 @@ networks to initiate server-to-server contact.
 
 # Scope
 
-The basis for the working group's efforts is the current [Open Cloud
+The basis for OCM is currently described in [Open Cloud
 Mesh Internet-Draft](https://datatracker.ietf.org/doc/draft-lopresti-open-cloud-mesh/).
 
 This draft outlines the general flows and structure of the protocol,


### PR DESCRIPTION
…starting point

This text change clarifies that draft-lopresti-open-cloud-mesh contains the current ideas of OCM but is not the working group's only choice going forward.